### PR TITLE
fix(ci): add id-token write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ name: release
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Adds `id-token: write` permission to the release workflow to fix the error:

```
The nested job 'release' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

The reusable workflow `metanorma/ci/.github/workflows/rubygems-release.yml@main` requires this permission for OIDC token generation.